### PR TITLE
Upgrade dependency versions and add Stack files

### DIFF
--- a/NXT.cabal
+++ b/NXT.cabal
@@ -34,11 +34,11 @@ Library
                        Robotics.NXT.Remote,
                        Robotics.NXT.Sensor.Compass,
                        Robotics.NXT.Sensor.Ultrasonic
-  Build-depends:       base >= 4.3 && < 5,
-                       mtl >= 1.1 && < 3,
-                       bytestring >= 0.9 && < 1,
-                       time >= 1.1 && < 2,
-                       serialport >= 0.4.3 && < 1
+  Build-depends:       base,
+                       mtl,
+                       bytestring,
+                       time,
+                       serialport
   Other-modules:       Robotics.NXT.Data,
                        Robotics.NXT.Errors,
                        Robotics.NXT.Protocol,
@@ -53,7 +53,7 @@ Library
   Default-language:    Haskell2010
 
   if !os(windows)
-    Build-depends:     unix >= 2.4 && < 3
+    Build-depends:     unix
 
   if os(linux)
     C-sources:         ffi/blue.c
@@ -67,46 +67,46 @@ Source-repository head
 Executable nxt-shutdown
   Main-is:             Shutdown.hs
   HS-source-dirs:      src
-  Build-depends:       base >= 4.3 && < 5,
-                       mtl >= 1.1 && < 3,
-                       NXT == 0.2.3
+  Build-depends:       base,
+                       mtl,
+                       NXT
   GHC-options:         -Wall
   Default-language:    Haskell2010
 
 Executable nxt-status
   Main-is:             Status.hs
   HS-source-dirs:      src
-  Build-depends:       base >= 4.3 && < 5,
-                       mtl >= 1.1 && < 3,
-                       NXT == 0.2.3
+  Build-depends:       base,
+                       mtl,
+                       NXT
   GHC-options:         -Wall
   Default-language:    Haskell2010
 
 Executable nxt-upload
   Main-is:             UploadFiles.hs
   HS-source-dirs:      src
-  Build-depends:       base >= 4.3 && < 5,
-                       mtl >= 1.1 && < 3,
-                       bytestring >= 0.9 && < 1,
-                       filepath >= 1.1 && < 2,
-                       NXT == 0.2.3
+  Build-depends:       base,
+                       mtl,
+                       bytestring,
+                       filepath,
+                       NXT
   GHC-options:         -Wall
   Default-language:    Haskell2010
 
 Test-suite nxt-tests
   Type:                exitcode-stdio-1.0
   X-uses-tf:           true
-  Build-depends:       base >= 4,
-                       HUnit >= 1.2 && < 2,
-                       QuickCheck >= 2.4 && < 3,
-                       test-framework >= 0.4 && < 1,
-                       test-framework-quickcheck2 >= 0.2 && < 1,
-                       test-framework-hunit >= 0.2 && < 1,
-                       mtl >= 1.1 && < 3,
-                       time >= 1.2 && < 2,
-                       bytestring >= 0.9 && < 1.0,
-                       filepath >= 1.2 && < 2,
-                       NXT == 0.2.3
+  Build-depends:       base,
+                       HUnit,
+                       QuickCheck,
+                       test-framework,
+                       test-framework-quickcheck2,
+                       test-framework-hunit,
+                       mtl,
+                       time,
+                       bytestring,
+                       filepath,
+                       NXT
   GHC-options:         -Wall -rtsopts
   Default-language:    Haskell2010
   HS-source-dirs:      tests

--- a/NXT.cabal
+++ b/NXT.cabal
@@ -34,11 +34,11 @@ Library
                        Robotics.NXT.Remote,
                        Robotics.NXT.Sensor.Compass,
                        Robotics.NXT.Sensor.Ultrasonic
-  Build-depends:       base,
-                       mtl,
-                       bytestring,
-                       time,
-                       serialport
+  Build-depends:       base >= 4.3 && < 5,
+                       mtl >= 1.1 && < 3,
+                       bytestring >= 0.9 && < 1,
+                       time >= 1.1 && < 2,
+                       serialport >= 0.4.3 && < 1
   Other-modules:       Robotics.NXT.Data,
                        Robotics.NXT.Errors,
                        Robotics.NXT.Protocol,
@@ -53,7 +53,7 @@ Library
   Default-language:    Haskell2010
 
   if !os(windows)
-    Build-depends:     unix
+    Build-depends:     unix >= 2.4 && < 3
 
   if os(linux)
     C-sources:         ffi/blue.c
@@ -67,46 +67,46 @@ Source-repository head
 Executable nxt-shutdown
   Main-is:             Shutdown.hs
   HS-source-dirs:      src
-  Build-depends:       base,
-                       mtl,
-                       NXT
+  Build-depends:       base >= 4.3 && < 5,
+                       mtl >= 1.1 && < 3,
+                       NXT == 0.2.3
   GHC-options:         -Wall
   Default-language:    Haskell2010
 
 Executable nxt-status
   Main-is:             Status.hs
   HS-source-dirs:      src
-  Build-depends:       base,
-                       mtl,
-                       NXT
+  Build-depends:       base >= 4.3 && < 5,
+                       mtl >= 1.1 && < 3,
+                       NXT == 0.2.3
   GHC-options:         -Wall
   Default-language:    Haskell2010
 
 Executable nxt-upload
   Main-is:             UploadFiles.hs
   HS-source-dirs:      src
-  Build-depends:       base,
-                       mtl,
-                       bytestring,
-                       filepath,
-                       NXT
+  Build-depends:       base >= 4.3 && < 5,
+                       mtl >= 1.1 && < 3,
+                       bytestring >= 0.9 && < 1,
+                       filepath >= 1.1 && < 2,
+                       NXT == 0.2.3
   GHC-options:         -Wall
   Default-language:    Haskell2010
 
 Test-suite nxt-tests
   Type:                exitcode-stdio-1.0
   X-uses-tf:           true
-  Build-depends:       base,
-                       HUnit,
-                       QuickCheck,
-                       test-framework,
-                       test-framework-quickcheck2,
-                       test-framework-hunit,
-                       mtl,
-                       time,
-                       bytestring,
-                       filepath,
-                       NXT
+  Build-depends:       base >= 4,
+                       HUnit >= 1.2 && < 2,
+                       QuickCheck >= 2.4 && < 3,
+                       test-framework >= 0.4 && < 1,
+                       test-framework-quickcheck2 >= 0.2 && < 1,
+                       test-framework-hunit >= 0.2 && < 1,
+                       mtl >= 1.1 && < 3,
+                       time >= 1.2 && < 2,
+                       bytestring >= 0.9 && < 1.0,
+                       filepath >= 1.2 && < 2,
+                       NXT == 0.2.3
   GHC-options:         -Wall -rtsopts
   Default-language:    Haskell2010
   HS-source-dirs:      tests

--- a/lib/Robotics/NXT/Internals.hs
+++ b/lib/Robotics/NXT/Internals.hs
@@ -12,7 +12,7 @@ import Robotics.NXT.Externals
 {-|
 Monad which encompasses interface to the NXT brick.
 -}
-newtype NXT a = NXT (StateT NXTInternals IO a) deriving (Monad, MonadIO, Functor, MonadFix) -- NXT monad
+newtype NXT a = NXT (StateT NXTInternals IO a) deriving (Monad, Applicative, MonadIO, Functor, MonadFix) -- NXT monad
 
 {-|
 A token used for exposed internal functions.

--- a/lib/Robotics/NXT/Sensor/Ultrasonic.hs
+++ b/lib/Robotics/NXT/Sensor/Ultrasonic.hs
@@ -39,7 +39,6 @@ module Robotics.NXT.Sensor.Ultrasonic (
   MeasurementNumber
 ) where
 
-import Control.Applicative
 import Control.Exception
 import Control.Monad
 import Control.Monad.Trans

--- a/src/UploadFiles.hs
+++ b/src/UploadFiles.hs
@@ -2,7 +2,6 @@ module Main (
   main
 ) where
 
-import Control.Applicative
 import Control.Monad.State
 import qualified Data.ByteString.Lazy as B
 import Data.Maybe

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,13 @@
+resolver: lts-5.3
+
+packages:
+- '.'
+
+extra-deps:
+- serialport-0.4.7
+- text-1.2.2.0
+
+flags: {}
+
+extra-package-dbs: []
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-5.3
+resolver: lts-5.4
 
 packages:
 - '.'

--- a/tests/Robotics/NXT/Basic.hs
+++ b/tests/Robotics/NXT/Basic.hs
@@ -1,6 +1,5 @@
 module Robotics.NXT.Basic where
 
-import Control.Applicative
 import Control.Monad.State hiding (state, runState)
 import qualified Data.ByteString.Lazy as B
 import Data.IORef


### PR DESCRIPTION
I've added Stack files to the repo as well as brought the dependencies up to date. Since the package was last updated, the Applicative Monad proposal has become a reality - making Applicative a superclass of Monad. I've made the albeit small modifications needed to suppress errors and warnings in light of this change.
